### PR TITLE
Add meta viewport tag so that generated pages are responsive

### DIFF
--- a/src/packages/cli/springtype/template/project/ionic-app/src/index.html
+++ b/src/packages/cli/springtype/template/project/ionic-app/src/index.html
@@ -5,6 +5,8 @@
 
     <meta charset="utf-8">
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <title>TemplateName SpringType / Ionic 4 app example</title>
 
     <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/src/packages/cli/springtype/template/project/scratch-webpack/src/index.html
+++ b/src/packages/cli/springtype/template/project/scratch-webpack/src/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
 
     <title>TemplateName</title>

--- a/src/packages/cli/springtype/template/project/scratch/src/index.html
+++ b/src/packages/cli/springtype/template/project/scratch/src/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
 
     <title>TemplateName</title>

--- a/src/packages/cli/springtype/template/project/todo/src/index.html
+++ b/src/packages/cli/springtype/template/project/todo/src/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <title>TemplateName TODO Example App</title>
 
     <!-- main application stylesheet entry-point -->


### PR DESCRIPTION
I wasn't sure whether or not to add the tag [here](https://github.com/springtype-org/springtype/blob/cc8c402e014f62d0a4a0fdf6fc957be6398c1a48/src/packages/ssr/src/function/register-jsdom.ts#L3) as well. Let me know if I should :+1: